### PR TITLE
Removed exclamation of current suit and badge when loading page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -653,6 +653,8 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
         } else {
           loc.suits[i][1] = false;
         }
+      } else {
+        loc.suits[i][1] = false;
       }
     }
     if (max[0] !== -1) {
@@ -684,6 +686,8 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
         } else {
           loc.badges[i][1] = false;
         }
+      } else {
+        loc.badges[i][1] = false;
       }
     }
     if (max[0] !== -1) {


### PR DESCRIPTION
When loading the Calculator site, if the suit/badge you are wearing gives a boost to the initial investment of a planet (a.k.a the investment(s) initially available when you reset the planet, like wearing the gold suit or wearing the "Rainbow Machine" badge on Moon, which affects Moon Shoes), although this suit/badge is checked, it still appears a "+" sign next to it.
This fix resets the "increase percentage" of the current item.