### PR TITLE
Save currently active tab (Issue 81)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -149,6 +149,16 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
       }
       reader.readAsText(file);
     });
+    var refWorld = localStorage.getItem('refWorld');
+    if (refWorld) {
+      var i = 0;
+      for (i in planets) {
+        if (planets[i] === refWorld) {
+          $scope.setWorld(refWorld);
+          break;
+        }
+      }
+    }
     var saved = localStorage.getItem('planets');
     if (saved) {
       loadExportedJson(saved);
@@ -1251,6 +1261,7 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
     $scope.fillBefore = [false, false];
     $scope.compare = false;
     $scope.ref = $scope[planet];
+    localStorage.setItem('refWorld', planet);
   };
 
   function suitFromName(name) {


### PR DESCRIPTION
As suggested in #81 and #84, this code stores the last world accessed by the user (Earth, Moon, Mars or <Current Event>), so that when loading/reloading the page, it automatically sets the active tab to the last used

(In the example given on #81, To first load the event tab is useless when there's no event running).