### PR TITLE
Custom amount in each investment's unlocks to show (Issue 71)

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,9 @@
             <uib-accordion-heading>
               Filter recommendations<span class="pull-right fa" ng-class="{'fa-chevron-down': accOpen2[1], 'fa-chevron-right': !accOpen2[1]}"></span>
             </uib-accordion-heading>
+            <label>Show <input type="number" class="form-control" min="1" data-ng-model="ref.unlockAmounts"># unlocks</label>
+            <br>
+            <br>
             <label><input type="checkbox" class="form-control" data-ng-model="ref.noSingles"> Don't show +1 upgrades</label>
             <label><input type="checkbox" class="form-control" data-ng-model="ref.noTens"> Don't show +10 upgrades</label>
             <label><input type="checkbox" class="form-control" data-ng-model="ref.noHundreds"> Don't show +100 upgrades</label>


### PR DESCRIPTION
In #71, I suggested to create, inside "Filter Recommendations", a number field to show how many of all investment's unlocks to show on the recommendations table.
If one wants to foresse the future steps he'll be taking (which investments to buy and so on), it may seem nice to see the cost to reach not just the next unlock, but it's next _X_ unlocks.
I got the idea by seeing that Newspapers show the next 3 unlocks, while the rest of the investments just show the immediate next.