### PR TITLE
Corrected E-Sports base speed

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1355,7 +1355,7 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
     $scope.lyp.baseCost =   [5,     88,    777,   22222, 444444, 99999999, 222222222, 5555555555, 33333333333];
     $scope.lyp.basePower =  [1.023, 1.046, 1.083, 1.166, 1.323,  2.286,    3.563,     6.126,      12.26];
     $scope.lyp.baseProfit = [0.5,   9,     81,    729,   7777,   1.111e6,  1.212e6,   161.616e6,  8.181e9];
-    $scope.lyp.baseSpeed =  [1.5,   5,     8,     18,    28,     120,      210,       370,        1400];
+    $scope.lyp.baseSpeed =  [1.5,   5,     8,     18,    28,     120,      210,       370,        700];
     $scope.lyp.hasMegaTickets = false;
     $scope.lyp.investments = [
       ['Belly Flopping', 1, false, 0, 0, 0, 0],


### PR DESCRIPTION
The correct base speed for E-Sports is 11min 40s (700 seconds). It was coded with the double amount (23min 20s, 1400 seconds)