### PR TITLE
Fix in case of # Angels are below 1 Million

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1337,11 +1337,12 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
   };
 
   function updateView(loc,varName, viewName, illionsName) {
-    var filtered = numFilter(loc[varName],false).split(' ');
-    loc[viewName] = Number(filtered[0]);
     if (loc[varName] < Number(1e+6)) {
+      loc[viewName] = loc[varName];
       loc[illionsName] = '';
     } else {
+      var filtered = numFilter(loc[varName],false).split(' ');
+      loc[viewName] = Number(filtered[0]);
       loc[illionsName] = filtered[1];
     }
   }


### PR DESCRIPTION
When the amount of Angels was between 1000 and 1 Million, it wasn't showing it on the screen, due to the locale (en-US) placing a thousand separator ( , ), which was failing the conversion to number.