### PR TITLE
Remove excessive transitions to improve performance

### DIFF
--- a/css/bonusstyle.css
+++ b/css/bonusstyle.css
@@ -50,12 +50,6 @@ label.strike-when-checked > input:checked + span {
   text-decoration: line-through;
 }
 
-
-/* Flair */
-* { transition: all 0.5s ease; }
-.fa { transition-duration: 0s; }
-
-
 /* Spacing & Alignment */
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td { vertical-align: middle; }
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th { text-align: center; }


### PR DESCRIPTION
Huge performance difference. Look at these screenshots from Chrome, while I was just moving the mouse around the recommendations table:

![2016-10-29_14 25 09_selection_001](https://cloud.githubusercontent.com/assets/121676/19829521/31959034-9de4-11e6-9eec-767c08be0208.png)

![2016-10-29_14 26 28_selection_001](https://cloud.githubusercontent.com/assets/121676/19829522/3a0aa79a-9de4-11e6-9cec-b9aa3dc9dac5.png)