### PR TITLE
Update angelScale for 1% Land event

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1772,7 +1772,7 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
       ['Macro Chips', 0, false, 0, 0, 0, 0],
       ['Mystery Meat', 0, false, 0, 0, 0, 0]
     ];
-    $scope.onepercent.angelScale = 45; // Currently Unknown
+    $scope.onepercent.angelScale = 150; // For March, 2018, replay
     $scope.onepercent.baseCost = [1, 20, 30, 50, 100, 200, 400, 1000, 19550717100000];
     $scope.onepercent.basePower = [1.1, 3, 2, 1.5, 1.05, 1.05, 1.05, 1.05, 6]; // 9
     $scope.onepercent.baseProfit = [4, 17, 25, 33, 2500, 5000, 8000, 10000, 1000000];


### PR DESCRIPTION
It appears that the angelScale for "1% Land" replay (March, 2018) is 150.

Lifetime earnings, Lifetime angels: 
1.1128e16, 500
7.2957e16, 1281
7.8738e16, 1331
8.9806e16, 1421
1.3851e17, 1765
1.91e17, 2073
2.0241e17, 2134
2.2654e17, 2257
2.5001e17, 2371
2.7125e17, 2470
2.8485e17, 2531
3.3808e17, 2758