### PR TITLE
Update Profit-A-Bowl

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1797,11 +1797,11 @@ advApp.controller('advController', ['$document', '$filter', '$scope', function($
       ['Capitalism Hill', 0, false, 0, 0, 0, 0]
     ];
     $scope.profitabowl.angelScale = 300;
-    $scope.profitabowl.baseCost = [5, 10, 200, 5000, 150000, 10e6, 500e6, 400e9, 400e9];
-    $scope.profitabowl.basePower = [1.0006999855, 3.2, 3, 2.8, 2.6, 2.4, 2.2, 2.1, 2];
+    $scope.profitabowl.baseCost = [4.996502448, 10, 200, 5000, 150000, 10e6, 500e6, 400e9, 400e9];
+    $scope.profitabowl.basePower = [1.0007, 3.2, 3, 2.8, 2.6, 2.4, 2.2, 2.1, 2];
     $scope.profitabowl.baseProfit = [0.5, 50, 350, 1650, 8000, 5e6, 69e6, 8e9, 12e9];
     $scope.profitabowl.baseSpeed = [1, 10, 15, 20, 30, 35, 40, 60, 60];
-    $scope.profitabowl.hasMegaTickets = false;
+    $scope.profitabowl.hasMegaTickets = true;
     $scope.profitabowl.ignorePlatinumBoost = true;
     $scope.profitabowl.investments = [
       ['Fake Fans', 1, false, 0, 0, 0, 0],


### PR DESCRIPTION
Adds "gilding"; corrects baseCost and basePower for "Fake Fans". The prices for "Fake Fans" were off by a few cents early on which led me to believe something was a just a titch off.

It seemed likely the basePower would be a "nice" number and baseCost would be either a nice number in and of itself or be a nice number related to basePower.

Since the initial purchase price of one "Fake Fans" was $5, I tried setting basePower to 1.007 (instead of 1.006999855) and baseCost to 5/1.0007 (4.996502448). That made the costs match up to reality more closely.

With the old settings, buying 100 more "Fake Fans" when owning 200 was priced at 595.08 but the calculator projected it to be 595.50; with the new settings, it's projected to be 595.08(321).